### PR TITLE
Add .gitattributes for Unity's files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Unity
+
+*.cs diff=csharp text
+*.cginc text
+*.shader text
+
+*.anim linguist-generated merge=unityyamlmerge diff eol=lf
+*.asset linguist-generated merge=unityyamlmerge diff eol=lf
+*.controller linguist-generated merge=unityyamlmerge diff eol=lf
+*.mat linguist-generated merge=unityyamlmerge diff eol=lf
+*.meta linguist-generated merge=unityyamlmerge diff eol=lf
+*.physicMaterial linguist-generated merge=unityyamlmerge diff eol=lf
+*.physicsMaterial2D linguist-generated merge=unityyamlmerge diff eol=lf
+*.prefab linguist-generated merge=unityyamlmerge diff eol=lf
+*.unity linguist-generated merge=unityyamlmerge diff eol=lf


### PR DESCRIPTION
Marks Unity-generated files as generated so that their diff is hidden by default in GitHub's UI. You can still use "Load diff" to load it, it's just that it doesn't load of all of these diffs slowing down the whole thing. Additionally, I've added the `merge=unityyamlmerge` attribute to those files to automatically use the [UnityYAMLMerge](https://docs.unity3d.com/Manual/SmartMerge.html) when conflict resolution of these files is required.

We may want to also consider using Git LFS but it does slightly affect the developer's workflow so I opted to not touch that until we decide to use that.