### PR TITLE
Add serialization support

### DIFF
--- a/Assets/Scripts/Model/Interfaces.meta
+++ b/Assets/Scripts/Model/Interfaces.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b78c86a0c85d42489f912aa95ffbfbfe
+timeCreated: 1699009317

--- a/Assets/Scripts/Model/Interfaces/ISerializableFrom.cs
+++ b/Assets/Scripts/Model/Interfaces/ISerializableFrom.cs
@@ -1,0 +1,9 @@
+namespace StereoApp.Model.Interfaces
+{
+    public interface ISerializableFrom<TSelf, out TActualType>
+        where TSelf : ISerializableFrom<TSelf, TActualType>
+        where TActualType : ISerializableTo<TActualType, TSelf>
+    {
+        public TActualType ToActualType();
+    }
+}

--- a/Assets/Scripts/Model/Interfaces/ISerializableFrom.cs.meta
+++ b/Assets/Scripts/Model/Interfaces/ISerializableFrom.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d276ff8bd59b4041a2f2b924574ba6cd
+timeCreated: 1699005769

--- a/Assets/Scripts/Model/Interfaces/ISerializableTo.cs
+++ b/Assets/Scripts/Model/Interfaces/ISerializableTo.cs
@@ -1,0 +1,9 @@
+namespace StereoApp.Model.Interfaces
+{
+    public interface ISerializableTo<TSelf, out TSerializedSelf>
+        where TSelf : ISerializableTo<TSelf, TSerializedSelf>
+        where TSerializedSelf : ISerializableFrom<TSerializedSelf, TSelf>
+    {
+        public TSerializedSelf ToSerializable();
+    }
+}

--- a/Assets/Scripts/Model/Interfaces/ISerializableTo.cs.meta
+++ b/Assets/Scripts/Model/Interfaces/ISerializableTo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5fbc9249016b49c98389cf86d8d90ca6
+timeCreated: 1699004637

--- a/Assets/Scripts/Model/JsonSerializable.cs
+++ b/Assets/Scripts/Model/JsonSerializable.cs
@@ -1,0 +1,24 @@
+using StereoApp.Model.Interfaces;
+using UnityEngine;
+
+namespace StereoApp.Model
+{
+    public static class JsonSerializable
+    {
+        public static TSelf FromJson<TSelf, TSerializedSelf>(string json)
+            where TSelf : ISerializableTo<TSelf, TSerializedSelf>
+            where TSerializedSelf : ISerializableFrom<TSerializedSelf, TSelf>
+        {
+            return JsonUtility.FromJson<TSerializedSelf>(json).ToActualType();
+        }
+
+        public static string ToJson<TSelf, TSerializedSelf>(
+            this ISerializableTo<TSelf, TSerializedSelf> self
+        )
+            where TSelf : ISerializableTo<TSelf, TSerializedSelf>
+            where TSerializedSelf : ISerializableFrom<TSerializedSelf, TSelf>
+        {
+            return JsonUtility.ToJson(self.ToSerializable());
+        }
+    }
+}

--- a/Assets/Scripts/Model/JsonSerializable.cs.meta
+++ b/Assets/Scripts/Model/JsonSerializable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6065a0ef74934479935284335cdcc0b7
+timeCreated: 1699012840

--- a/Assets/Scripts/Model/Point.cs
+++ b/Assets/Scripts/Model/Point.cs
@@ -1,6 +1,9 @@
+using System;
+using StereoApp.Model.Interfaces;
+
 namespace StereoApp.Model
 {
-    public class Point
+    public class Point : ISerializableTo<Point, SerializedPoint>
     {
         public float X { get; }
         public float Y { get; }
@@ -13,6 +16,16 @@ namespace StereoApp.Model
             Z = z;
         }
 
+        public SerializedPoint ToSerializable()
+        {
+            return new SerializedPoint
+            {
+                x = X,
+                y = Y,
+                z = Z
+            };
+        }
+
         public static Point operator +(Point a, Point b)
         {
             return new Point(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
@@ -21,6 +34,19 @@ namespace StereoApp.Model
         public static Point operator -(Point a, Point b)
         {
             return new Point(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+        }
+    }
+
+    [Serializable]
+    public class SerializedPoint : ISerializableFrom<SerializedPoint, Point>
+    {
+        public float x;
+        public float y;
+        public float z;
+
+        public Point ToActualType()
+        {
+            return new Point(x, y, z);
         }
     }
 }

--- a/Assets/Scripts/Model/Polygon.cs
+++ b/Assets/Scripts/Model/Polygon.cs
@@ -1,15 +1,19 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using StereoApp.Model.Interfaces;
 using UnityEngine;
 
 namespace StereoApp.Model
 {
-    public class Polygon : IList<Point>, INotifyCollectionChanged, INotifyPropertyChanged
+    public class Polygon
+        : ISerializableTo<Polygon, SerializedPolygon>,
+            IList<Point>,
+            INotifyCollectionChanged,
+            INotifyPropertyChanged
     {
         private const float CoplanarTolerance = 1e-5f;
         private readonly List<Point> _points;
@@ -39,6 +43,14 @@ namespace StereoApp.Model
                 Debug.Assert(IsCoplanar(point));
             }
 #endif
+        }
+
+        public SerializedPolygon ToSerializable()
+        {
+            return new SerializedPolygon
+            {
+                points = _points.Select(point => point.ToSerializable()).ToList()
+            };
         }
 
         private bool IsCoplanar(Point point)
@@ -208,6 +220,17 @@ namespace StereoApp.Model
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
             CollectionChanged?.Invoke(this, e);
+        }
+    }
+
+    [Serializable]
+    public class SerializedPolygon : ISerializableFrom<SerializedPolygon, Polygon>
+    {
+        public List<SerializedPoint> points;
+
+        public Polygon ToActualType()
+        {
+            return new Polygon(points.Select(point => point.ToActualType()));
         }
     }
 }

--- a/Assets/Scripts/Model/Project.cs
+++ b/Assets/Scripts/Model/Project.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using StereoApp.Model.Interfaces;
+using UnityEngine;
+
+namespace StereoApp.Model
+{
+    public class Project : ISerializableTo<Project, SerializedProject>
+    {
+        public static readonly string ProjectsDir = Path.Join(
+            Application.persistentDataPath,
+            "projects"
+        );
+
+        public SolidFigure Figure { get; set; }
+        public string ProjectName { get; set; }
+
+        public Project(SolidFigure figure)
+        {
+            Figure = figure;
+        }
+
+        public SerializedProject ToSerializable()
+        {
+            return new SerializedProject { figure = Figure.ToSerializable() };
+        }
+
+        public static Project FromProjectName(string projectName)
+        {
+            var projectPath = Path.Join(ProjectsDir, projectName);
+            using var fs = new StreamReader(projectPath);
+            var project = JsonSerializable.FromJson<Project, SerializedProject>(fs.ReadToEnd());
+            project.ProjectName = projectName;
+            return project;
+        }
+
+        public void Save()
+        {
+            if (ProjectName is null)
+            {
+                throw new InvalidOperationException("Project name is not set.");
+            }
+
+            var projectPath = Path.Join(ProjectsDir, ProjectName);
+            var tmpProjectPath = projectPath + ".tmp";
+
+            Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+
+            try
+            {
+                using var fs = new StreamWriter(tmpProjectPath);
+                fs.Write(this.ToJson());
+                fs.Close();
+
+                // atomic operation
+                File.Replace(tmpProjectPath, projectPath, null);
+                // Unity is still on .NET Standard 2.1 and doesn't support File.Move() with
+                // override argument that I should be using here instead but I guess this works...
+            }
+            finally
+            {
+                File.Delete(tmpProjectPath);
+            }
+        }
+    }
+
+    [Serializable]
+    public class SerializedProject : ISerializableFrom<SerializedProject, Project>
+    {
+        public SerializedSolidFigure figure;
+
+        public Project ToActualType()
+        {
+            return new Project(figure.ToActualType());
+        }
+    }
+}

--- a/Assets/Scripts/Model/Project.cs.meta
+++ b/Assets/Scripts/Model/Project.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c8dfa214fdf74fe881f497890c3c56ea
+timeCreated: 1699007495

--- a/Assets/Scripts/Model/SolidFigure.cs
+++ b/Assets/Scripts/Model/SolidFigure.cs
@@ -1,7 +1,41 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
+using StereoApp.Model.Interfaces;
 
 namespace StereoApp.Model
 {
     // name of this class is a simplification - we do not verify in any way that it represents a closed figure
-    public class SolidFigure : ObservableCollection<Polygon> { }
+    public class SolidFigure
+        : ObservableCollection<Polygon>,
+            ISerializableTo<SolidFigure, SerializedSolidFigure>
+    {
+        public SolidFigure() { }
+
+        public SolidFigure(IEnumerable<Polygon> collection)
+            : base(collection) { }
+
+        public SolidFigure(List<Polygon> list)
+            : base(list) { }
+
+        public SerializedSolidFigure ToSerializable()
+        {
+            return new SerializedSolidFigure
+            {
+                polygons = this.Select(polygon => polygon.ToSerializable()).ToList()
+            };
+        }
+    }
+
+    [Serializable]
+    public class SerializedSolidFigure : ISerializableFrom<SerializedSolidFigure, SolidFigure>
+    {
+        public List<SerializedPolygon> polygons;
+
+        public SolidFigure ToActualType()
+        {
+            return new SolidFigure(polygons.Select(polygon => polygon.ToActualType()));
+        }
+    }
 }


### PR DESCRIPTION
Makes all used models serializable and adds a new `Project` class that will, in the future, represent the state of the whole project and allow loading and saving it from/to a file in the application's persistent data path.

For now, project-related operations have not been implemented as the functionality we will implement is driven by what we end up implementing in UI.
I imagine we will want a way to browse through projects and make sure that we ask for confirmation when the user tries to override an existing project with a different one but it's not complicated to do so there's not really much point in doing it before we need it.