### PR TITLE
Make Point instances mutable

### DIFF
--- a/Assets/Scripts/Model/Point.cs
+++ b/Assets/Scripts/Model/Point.cs
@@ -1,19 +1,76 @@
 using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using StereoApp.Model.Interfaces;
 
 namespace StereoApp.Model
 {
-    public class Point : ISerializableTo<Point, SerializedPoint>
+    public class Point : ISerializableTo<Point, SerializedPoint>, INotifyPropertyChanged
     {
-        public float X { get; }
-        public float Y { get; }
-        public float Z { get; }
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private string _label = "";
+        public string Label
+        {
+            get => _label;
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException();
+                }
+
+                _label = value;
+                OnPropertyChanged();
+            }
+        }
+        private float _x;
+        public float X
+        {
+            get => _x;
+            set
+            {
+                _x = value;
+                OnPropertyChanged();
+            }
+        }
+        private float _y;
+        public float Y
+        {
+            get => _y;
+            set
+            {
+                _y = value;
+                OnPropertyChanged();
+            }
+        }
+        private float _z;
+        public float Z
+        {
+            get => _z;
+            set
+            {
+                _z = value;
+                OnPropertyChanged();
+            }
+        }
 
         public Point(float x, float y, float z)
         {
             X = x;
             Y = y;
             Z = z;
+        }
+
+        public Point(float x, float y, float z, string label)
+            : this(x, y, z)
+        {
+            Label = label;
+        }
+
+        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 
         public SerializedPoint ToSerializable()
@@ -28,12 +85,12 @@ namespace StereoApp.Model
 
         public static Point operator +(Point a, Point b)
         {
-            return new Point(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+            return new Point(a.X + b.X, a.Y + b.Y, a.Z + b.Z, a.Label);
         }
 
         public static Point operator -(Point a, Point b)
         {
-            return new Point(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+            return new Point(a.X + b.X, a.Y + b.Y, a.Z + b.Z, a.Label);
         }
     }
 

--- a/Assets/Scripts/Model/Polygon.cs
+++ b/Assets/Scripts/Model/Polygon.cs
@@ -181,36 +181,36 @@ namespace StereoApp.Model
             get => _points[index];
             set
             {
-                if (_points.Count == 3)
+                if (_points.Count != 3)
                 {
-                    _points[index] = value;
-                    return;
+                    bool isCoplanar;
+                    if (index < 2)
+                    {
+                        // temporary swap
+                        (_points[index], _points[3]) = (_points[3], _points[index]);
+                        isCoplanar = IsCoplanar(value);
+                        (_points[index], _points[3]) = (_points[3], _points[index]);
+                    }
+                    else
+                    {
+                        isCoplanar = IsCoplanar(value);
+                    }
+
+                    if (!isCoplanar)
+                    {
+                        throw new ArgumentException(
+                            "The point is not coplanar with existing points."
+                        );
+                    }
                 }
 
-                bool isCoplanar;
-                if (index < 2)
-                {
-                    // temporary swap
-                    (_points[index], _points[3]) = (_points[3], _points[index]);
-                    isCoplanar = IsCoplanar(value);
-                    (_points[index], _points[3]) = (_points[3], _points[index]);
-                }
-                else
-                {
-                    isCoplanar = IsCoplanar(value);
-                }
-
-                if (!isCoplanar)
-                {
-                    throw new ArgumentException("The point is not coplanar with existing points.");
-                }
-
+                var oldValue = _points[index];
                 _points[index] = value;
                 OnCollectionChanged(
                     new NotifyCollectionChangedEventArgs(
                         NotifyCollectionChangedAction.Replace,
                         value,
-                        index
+                        oldValue
                     )
                 );
             }

--- a/Assets/Scripts/Model/SolidFigure.cs
+++ b/Assets/Scripts/Model/SolidFigure.cs
@@ -11,6 +11,8 @@ namespace StereoApp.Model
         : ObservableCollection<Polygon>,
             ISerializableTo<SolidFigure, SerializedSolidFigure>
     {
+        public ISet<Point> Points => new HashSet<Point>(this.SelectMany(polygon => polygon));
+
         public SolidFigure() { }
 
         public SolidFigure(IEnumerable<Polygon> collection)

--- a/Assets/Scripts/Presenter/PolygonPresenter.cs
+++ b/Assets/Scripts/Presenter/PolygonPresenter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using StereoApp.Model;
@@ -29,12 +30,22 @@ namespace StereoApp.Presenter
             {
                 if (_polygon != null)
                 {
+                    foreach (var point in _polygon)
+                    {
+                        point.PropertyChanged -= OnPointChanged;
+                    }
+
                     _polygon.CollectionChanged -= OnPolygonCollectionChanged;
                 }
 
                 _polygon = value;
                 if (value != null)
                 {
+                    foreach (var point in value)
+                    {
+                        point.PropertyChanged += OnPointChanged;
+                    }
+
                     value.CollectionChanged += OnPolygonCollectionChanged;
                 }
 
@@ -60,8 +71,43 @@ namespace StereoApp.Presenter
             Destroy(_meshRenderer);
         }
 
+        private void OnPointChanged(object sender, PropertyChangedEventArgs e)
+        {
+            UpdateMesh();
+        }
+
         private void OnPolygonCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    foreach (Model.Point point in e.NewItems)
+                    {
+                        point.PropertyChanged += OnPointChanged;
+                    }
+
+                    break;
+                case NotifyCollectionChangedAction.Remove:
+                    foreach (Model.Point point in e.OldItems)
+                    {
+                        point.PropertyChanged -= OnPointChanged;
+                    }
+
+                    break;
+                case NotifyCollectionChangedAction.Replace:
+                    foreach (Model.Point point in e.OldItems)
+                    {
+                        point.PropertyChanged -= OnPointChanged;
+                    }
+
+                    foreach (Model.Point point in e.NewItems)
+                    {
+                        point.PropertyChanged += OnPointChanged;
+                    }
+
+                    break;
+            }
+
             UpdateMesh();
         }
 


### PR DESCRIPTION
This PR more or less resolves the concern about it being hard to modify a point shared between polygons. `SolidFigure` currently makes no effort to figure out if a point with the same coordinates but different references are shared between `Polygon` instances *but* if multiple `Polygon`s receive the same reference to a `Point` then any modification of that `Point` will affect all of them (and all relevant `PolygonPresenter`s will update the meshes appropriately as well).