### PR TITLE
Add support for Android back button

### DIFF
--- a/Assets/Scripts/AppManager.cs
+++ b/Assets/Scripts/AppManager.cs
@@ -15,6 +15,7 @@ namespace StereoApp
                 Destroy(this.gameObject);
                 return;
             }
+            Screen.fullScreen = false;
             Instance = this;
             DontDestroyOnLoad(this.gameObject);
         }

--- a/Assets/Scripts/Presenter/UIHandlers/MenuManager.cs
+++ b/Assets/Scripts/Presenter/UIHandlers/MenuManager.cs
@@ -20,6 +20,15 @@ namespace StereoApp.Presenter.UIHandlers
             current = mainMenu.gameObject;
         }
 
+        protected virtual void Update()
+        {
+            // back button on Android
+            if (Input.GetKeyUp(KeyCode.Escape))
+            {
+                GoBack();
+            }
+        }
+
         public void ShowMainMenu()
         {
             SwitchToMenu(mainMenu);
@@ -34,7 +43,7 @@ namespace StereoApp.Presenter.UIHandlers
             obj.SetActive(true);
         }
 
-        public void GoBack()
+        public virtual void GoBack()
         {
             if (LastMenus.Count == 0)
             {

--- a/Assets/Scripts/Presenter/UIHandlers/ToolbarMenu/ToolbarMenuManager.cs
+++ b/Assets/Scripts/Presenter/UIHandlers/ToolbarMenu/ToolbarMenuManager.cs
@@ -45,6 +45,16 @@ namespace StereoApp.Presenter.UIHandlers.ToolbarMenu
             cameraMovement = Camera.main.GetComponent<CameraMovement>();
         }
 
+        public override void GoBack()
+        {
+            if (LastMenus.Count == 0 && toolbarMenu.gameObject.activeSelf)
+            {
+                OnMenuButtonPressed();
+                return;
+            }
+            base.GoBack();
+        }
+
         public void OnMenuButtonPressed()
         {
             if (!toolbarMenu.gameObject.activeSelf)


### PR DESCRIPTION
Simple change, Android's back button now works in the menus + allows collapsing the toolbar menu if one can't go back further. To make this make sense, it also enables the navigation bar (`Screen.fullScreen = false`). The notification bar is still hidden though.